### PR TITLE
Fix streaming method call in BaseAgent

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -124,7 +124,7 @@ class BaseAgent(ABC):
             Text chunks as they are generated
         """
         try:
-            async for chunk in self.llm_interface.generate_streaming_text(
+            async for chunk in self.llm_interface.stream_text(
                 prompt=prompt,
                 model=model_name or self.get_model_name(),
                 temperature=temperature or self.temperature


### PR DESCRIPTION
## Summary
- fix call to non-existent generate_streaming_text

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f99f472008321a09ce1d0e2187d2e