### PR TITLE
Fix OllamaInterface init in LLM orchestrator test

### DIFF
--- a/agents/llm_driven_orchestrator.py
+++ b/agents/llm_driven_orchestrator.py
@@ -278,10 +278,7 @@ async def test_llm_driven_orchestrator():
         config = load_config("config.yaml")
         
         # Create LLM interface (will fail without Ollama, but that's ok for structure test)
-        llm_interface = OllamaInterface(
-            url=config.ollama_settings.url,
-            default_model=config.ollama_settings.orchestrator_model
-        )
+        llm_interface = OllamaInterface(config=config)
         
         # Create orchestrator
         orchestrator = LLMDrivenOrchestrator(


### PR DESCRIPTION
## Summary
- use config-based initialization for `OllamaInterface` in `test_llm_driven_orchestrator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9bb7c6fc83219c7fc829138b8da4